### PR TITLE
Updates dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function(opts) {
 
     if (opts.init) {
       if (!bs) bs = yield browserSync(null, opts);
-      snippet = bs[0].options.snippet
+      snippet = bs.getOption('snippet');
     } else {
       snippet = process.env.BROWSERSYNC_SNIPPET;
     }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/SimonDegraeve/koa-browser-sync",
   "dependencies": {
+    "browser-sync": "^2.14.0",
     "stream-injecter": "0.0.1",
-    "browser-sync": "1.6.5",
-    "thunkify": "2.1.2"
+    "thunkify": "^2.1.2"
   }
 }


### PR DESCRIPTION
This updates BrowerSync to v2 and adjusts the snippet grabbing code. I'll probably write a PR shortly that updates it to use the new Promise-based syntax in Koa 2.
